### PR TITLE
Fix mobile input zoom and chat pending state

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -180,3 +180,11 @@
     opacity: 1;
   }
 }
+
+@media (max-width: 640px) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}

--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -182,7 +182,7 @@ export function AgentChat() {
 
   useEffect(() => {
     if (!isOpen || !activeConversationId) {
-      if (!activeConversationId) {
+      if (!activeConversationId && !isSending) {
         setMessages([]);
       }
       return;
@@ -206,7 +206,7 @@ export function AgentChat() {
         setIsLoadingMessages(false);
       }
     })();
-  }, [activeConversationId, isOpen]);
+  }, [activeConversationId, isOpen, isSending]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });


### PR DESCRIPTION
### Motivation
- Éviter d’effacer l’historique de messages du chat lorsqu’un envoi est en cours afin de conserver l’état « en attente » visible. 
- Empêcher le zoom automatique sur mobile en forçant une taille de police lisible pour les champs de saisie.

### Description
- Modifie `components/agent/agent-chat.tsx` pour ne pas appeler `setMessages([])` quand `isSending` est vrai, afin de préserver les messages temporaires utilisateur/assistant pendant l’envoi. 
- Ajoute `isSending` aux dépendances du `useEffect` qui charge les messages pour garantir un comportement cohérent lors d’un envoi en cours.
- Ajoute une règle CSS dans `app/globals.css` : un `@media (max-width: 640px)` qui force `font-size: 16px` pour `input`, `textarea` et `select` afin d’éviter le zoom automatique des navigateurs mobiles.

### Testing
- Exécuté `npm run dev -- --hostname 0.0.0.0 --port 3000`, résultat : échec car `next` introuvable (`sh: 1: next: not found`).
- Tentative de `npm install` lancée mais l’installation n’a pas abouti/complété dans l’environnement (processus interrompu / warnings de runtime), donc serveur non démarré et tests d’intégration non exécutés.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988eb9525ac8333a5fb18b241d4ee00)