### PR TITLE
Ajout des notifications in-app et par e-mail

### DIFF
--- a/app/(app)/app/notifications/page.tsx
+++ b/app/(app)/app/notifications/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { format } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/house";
+import { markAllNotificationsRead, markNotificationRead } from "@/app/actions";
+
+export default async function NotificationsPage() {
+  const session = await requireSession();
+  const notifications = await prisma.notification.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "desc" },
+    take: 80,
+  });
+
+  const unreadCount = notifications.filter((notification) => !notification.readAt)
+    .length;
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-muted-foreground">Centre de notifications</p>
+          <h1 className="text-2xl font-semibold">Notifications</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          {unreadCount > 0 ? (
+            <form action={markAllNotificationsRead}>
+              <Button type="submit" variant="outline" size="sm">
+                Tout marquer comme lu
+              </Button>
+            </form>
+          ) : null}
+        </div>
+      </header>
+
+      {notifications.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            Aucune notification pour le moment.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {notifications.map((notification) => {
+            const createdAt = format(notification.createdAt, "dd/MM/yyyy HH:mm");
+            return (
+              <Card key={notification.id}>
+                <CardHeader className="space-y-2 pb-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <CardTitle className="text-base font-semibold">
+                      {notification.title}
+                    </CardTitle>
+                    <div className="flex items-center gap-2">
+                      {notification.readAt ? null : (
+                        <Badge variant="secondary">Non lu</Badge>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        {createdAt}
+                      </span>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {notification.body ? (
+                    <p className="text-sm text-muted-foreground">
+                      {notification.body}
+                    </p>
+                  ) : null}
+                  <div className="flex flex-wrap items-center gap-3">
+                    {notification.linkUrl ? (
+                      <Button asChild size="sm" variant="secondary">
+                        <Link href={notification.linkUrl}>Ouvrir</Link>
+                      </Button>
+                    ) : null}
+                    {notification.readAt ? null : (
+                      <form action={markNotificationRead}>
+                        <input
+                          type="hidden"
+                          name="notificationId"
+                          value={notification.id}
+                        />
+                        <Button type="submit" size="sm" variant="ghost">
+                          Marquer comme lu
+                        </Button>
+                      </form>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import { ConfettiOverlay } from "@/components/tasks/confetti-overlay";
 import { requireHouse, requireSession } from "@/lib/house";
+import { getUnreadNotificationCount } from "@/lib/notifications";
 import { AppShell } from "@/components/layout/app-shell";
 
 export default async function AppLayout({
@@ -9,6 +10,7 @@ export default async function AppLayout({
 }) {
   const session = await requireSession();
   const membership = await requireHouse(session.user.id);
+  const unreadNotifications = await getUnreadNotificationCount(session.user.id);
 
   return (
     <AppShell
@@ -16,6 +18,7 @@ export default async function AppLayout({
       houseIconUrl={membership.house.iconUrl}
       userName={session.user.name}
       userEmail={session.user.email}
+      unreadNotifications={unreadNotifications}
     >
       <ConfettiOverlay />
       {children}

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -17,6 +17,13 @@ import { getBudgetRuntimeDelegates, withBudgetTablesGuard } from "@/lib/budget";
 import { prisma } from "@/lib/db";
 import { buildInviteUrl, hasEmailServerConfig, sendEmail } from "@/lib/email";
 import { buildImportantDateOccurrences } from "@/lib/important-dates";
+import {
+  notifyInviteAccepted,
+  notifyProjectCreated,
+  notifyTaskAssigned,
+  notifyTaskCommented,
+  notifyTaskStatusChanged,
+} from "@/lib/notifications";
 import { z } from "zod";
 
 const nameSchema = z
@@ -801,6 +808,7 @@ function revalidateApp() {
   revalidatePath("/app/budgets");
   revalidatePath("/app/shopping-lists");
   revalidatePath("/app/settings");
+  revalidatePath("/app/notifications");
 }
 
 export async function createHouse(formData: FormData) {
@@ -976,7 +984,7 @@ export async function createProject(formData: FormData) {
 
   await requireOwner(userId, houseId);
 
-  await prisma.project.create({
+  const project = await prisma.project.create({
     data: {
       houseId,
       name,
@@ -984,6 +992,14 @@ export async function createProject(formData: FormData) {
       startsAt,
       endsAt,
     },
+    select: { id: true, name: true },
+  });
+
+  await notifyProjectCreated({
+    houseId,
+    projectId: project.id,
+    projectName: project.name,
+    actorId: userId,
   });
 
   revalidateApp();
@@ -2034,6 +2050,16 @@ export async function createTask(formData: FormData) {
       },
     });
 
+    if (validAssigneeId) {
+      await notifyTaskAssigned({
+        houseId,
+        taskId: instance.id,
+        taskTitle: title,
+        assigneeId: validAssigneeId,
+        actorId: userId,
+      });
+    }
+
     await generateAndAttachTaskImage(instance.id, title, description);
   } else {
     const created = await prisma.task.create({
@@ -2057,6 +2083,16 @@ export async function createTask(formData: FormData) {
       },
     });
 
+    if (validAssigneeId) {
+      await notifyTaskAssigned({
+        houseId,
+        taskId: created.id,
+        taskTitle: title,
+        assigneeId: validAssigneeId,
+        actorId: userId,
+      });
+    }
+
     await generateAndAttachTaskImage(created.id, title, description);
   }
 
@@ -2071,7 +2107,13 @@ export async function updateTaskStatus(formData: FormData) {
 
   const task = await prisma.task.findUnique({
     where: { id: taskId },
-    select: { houseId: true },
+    select: {
+      houseId: true,
+      status: true,
+      title: true,
+      createdById: true,
+      assigneeId: true,
+    },
   });
 
   if (!task) {
@@ -2085,6 +2127,24 @@ export async function updateTaskStatus(formData: FormData) {
     data: { status },
   });
 
+  if (task.status !== status && status === "DONE") {
+    const recipients = [task.createdById, task.assigneeId].filter(
+      (id): id is string => Boolean(id)
+    );
+    await Promise.all(
+      recipients.map((recipientId) =>
+        notifyTaskStatusChanged({
+          houseId: task.houseId,
+          taskId,
+          taskTitle: task.title,
+          recipientId,
+          actorId: userId,
+          status,
+        })
+      )
+    );
+  }
+
   revalidateApp();
 }
 
@@ -2095,7 +2155,7 @@ export async function updateTaskAssignee(formData: FormData) {
 
   const task = await prisma.task.findUnique({
     where: { id: taskId },
-    select: { houseId: true },
+    select: { houseId: true, assigneeId: true, title: true },
   });
 
   if (!task) {
@@ -2120,6 +2180,16 @@ export async function updateTaskAssignee(formData: FormData) {
     data: { assigneeId },
   });
 
+  if (assigneeId && assigneeId !== task.assigneeId) {
+    await notifyTaskAssigned({
+      houseId: task.houseId,
+      taskId,
+      taskTitle: task.title,
+      assigneeId,
+      actorId: userId,
+    });
+  }
+
   revalidateApp();
 }
 
@@ -2138,6 +2208,7 @@ export async function updateTask(formData: FormData) {
       recurrenceUnit: true,
       recurrenceInterval: true,
       createdById: true,
+      assigneeId: true,
       parent: {
         select: {
           id: true,
@@ -2422,6 +2493,16 @@ export async function updateTask(formData: FormData) {
     });
   }
 
+  if (assigneeId && assigneeId !== task.assigneeId) {
+    await notifyTaskAssigned({
+      houseId: task.houseId,
+      taskId,
+      taskTitle: title,
+      assigneeId,
+      actorId: userId,
+    });
+  }
+
   revalidateApp();
   revalidatePath(`/app/tasks/${taskId}`);
 }
@@ -2462,7 +2543,7 @@ export async function addTaskComment(formData: FormData) {
 
   const task = await prisma.task.findUnique({
     where: { id: taskId },
-    select: { houseId: true },
+    select: { houseId: true, title: true, createdById: true, assigneeId: true },
   });
 
   if (!task) {
@@ -2478,6 +2559,21 @@ export async function addTaskComment(formData: FormData) {
       content,
     },
   });
+
+  const recipients = [task.createdById, task.assigneeId].filter(
+    (id): id is string => Boolean(id)
+  );
+  await Promise.all(
+    recipients.map((recipientId) =>
+      notifyTaskCommented({
+        houseId: task.houseId,
+        taskId,
+        taskTitle: task.title,
+        recipientId,
+        actorId: userId,
+      })
+    )
+  );
 
   revalidateApp();
   revalidatePath(`/app/tasks/${taskId}`);
@@ -2668,11 +2764,20 @@ export async function applyTaskSuggestion(formData: FormData) {
 }
 
 export async function acceptHouseInvite(formData: FormData) {
-  const { id: userId, email } = await requireSessionUser();
+  const { id: userId, email, name } = await requireSessionUser();
   const token = z.string().min(10).parse(formData.get("token"));
 
   const invite = await prisma.houseInvite.findUnique({
     where: { token },
+    select: {
+      id: true,
+      houseId: true,
+      status: true,
+      expiresAt: true,
+      email: true,
+      role: true,
+      createdById: true,
+    },
   });
 
   if (!invite) {
@@ -2715,6 +2820,14 @@ export async function acceptHouseInvite(formData: FormData) {
       data: { status: "ACCEPTED", acceptedAt: new Date() },
     });
   });
+
+  if (invite.createdById) {
+    await notifyInviteAccepted({
+      houseId: invite.houseId,
+      inviterId: invite.createdById,
+      inviteeName: name,
+    });
+  }
 
   revalidateApp();
   redirect("/app");
@@ -2901,4 +3014,29 @@ export async function generateSuggestedTasks(formData: FormData) {
   }
 
   revalidateApp();
+}
+
+export async function markNotificationRead(formData: FormData) {
+  const userId = await requireUser();
+  const notificationId = z.string().cuid().parse(formData.get("notificationId"));
+
+  await prisma.notification.updateMany({
+    where: { id: notificationId, userId },
+    data: { readAt: new Date() },
+  });
+
+  revalidateApp();
+  revalidatePath("/app/notifications");
+}
+
+export async function markAllNotificationsRead() {
+  const userId = await requireUser();
+
+  await prisma.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  });
+
+  revalidateApp();
+  revalidatePath("/app/notifications");
 }

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -10,12 +10,14 @@ export function AppShell({
   houseIconUrl,
   userName,
   userEmail,
+  unreadNotifications,
   children,
 }: {
   houseName: string;
   houseIconUrl?: string | null;
   userName?: string | null;
   userEmail?: string | null;
+  unreadNotifications?: number;
   children: React.ReactNode;
 }) {
   const [collapsed, setCollapsed] = useState(false);
@@ -89,6 +91,7 @@ export function AppShell({
           houseIconUrl={houseIconUrl}
           userName={userName}
           userEmail={userEmail}
+          unreadNotifications={unreadNotifications}
           collapsed={collapsed}
           onToggle={toggle}
         />
@@ -137,6 +140,7 @@ export function AppShell({
         houseIconUrl={houseIconUrl}
         userName={userName}
         userEmail={userEmail}
+        unreadNotifications={unreadNotifications}
         collapsed={false}
         mobile
         isOpen={mobileMenuOpen}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Hammer,
   Home,
   Landmark,
+  Bell,
   Package,
   PanelLeftClose,
   PanelLeftOpen,
@@ -19,6 +20,7 @@ import { SignOutButton } from "@/components/auth/sign-out-button";
 
 const primaryNav = [
   { href: "/app", label: "Vue globale", icon: Home },
+  { href: "/app/notifications", label: "Notifications", icon: Bell },
   { href: "/app/tasks", label: "Tâches", icon: CheckSquare2 },
   { href: "/app/calendar", label: "Calendrier", icon: CalendarDays },
   { href: "/app/budgets", label: "Budgets", icon: Landmark },
@@ -34,6 +36,7 @@ export function Sidebar({
   houseIconUrl,
   userName,
   userEmail,
+  unreadNotifications = 0,
   collapsed = false,
   onToggle,
   mobile = false,
@@ -44,6 +47,7 @@ export function Sidebar({
   houseIconUrl?: string | null;
   userName?: string | null;
   userEmail?: string | null;
+  unreadNotifications?: number;
   collapsed?: boolean;
   onToggle?: () => void;
   mobile?: boolean;
@@ -129,6 +133,8 @@ export function Sidebar({
             {primaryNav.map((item) => {
               const isActive = pathname === item.href;
               const Icon = item.icon;
+              const showBadge =
+                item.href === "/app/notifications" && unreadNotifications > 0;
               return (
                 <Link
                   key={item.href}
@@ -143,7 +149,14 @@ export function Sidebar({
                 >
                   <Icon className="h-4 w-4 shrink-0" />
                   {!isCollapsed ? (
-                    <span className="truncate">{item.label}</span>
+                    <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                      <span className="truncate">{item.label}</span>
+                      {showBadge ? (
+                        <span className="rounded-full bg-rose-500 px-2 py-0.5 text-xs font-semibold text-white">
+                          {unreadNotifications}
+                        </span>
+                      ) : null}
+                    </span>
                   ) : null}
                 </Link>
               );

--- a/lib/house.ts
+++ b/lib/house.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { authOptions } from "@/auth";
 import { prisma } from "@/lib/db";
 import { ensureRecurringTasks } from "@/lib/recurrence";
+import { ensureTaskReminders } from "@/lib/notifications";
 
 type ShoppingListWithItems = Prisma.ShoppingListGetPayload<{
   include: { items: true };
@@ -82,6 +83,7 @@ export async function getHouseData(userId: string) {
   const houseId = membership.houseId;
 
   await ensureRecurringTasks(houseId);
+  await ensureTaskReminders(houseId);
 
   let shoppingListsReady = true;
   let shoppingLists: ShoppingListWithItems[] = [];

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,309 @@
+import { Prisma } from "@prisma/client";
+import { format, isSameDay, startOfDay, subDays } from "date-fns";
+import { prisma } from "@/lib/db";
+import { getAppBaseUrl, sendEmail } from "@/lib/email";
+
+type NotificationOptions = {
+  userId: string;
+  houseId: string;
+  type: "TASK_ASSIGNED" | "TASK_COMMENTED" | "TASK_STATUS" | "TASK_REMINDER" | "PROJECT_CREATED" | "INVITE_ACCEPTED";
+  title: string;
+  body?: string | null;
+  linkUrl?: string | null;
+  dedupeKey?: string | null;
+  sendEmail?: boolean;
+};
+
+function isNotificationUnavailableError(error: unknown) {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    (error.code === "P2021" || error.code === "P2022")
+  );
+}
+
+function resolveNotificationUrl(linkUrl?: string | null) {
+  const baseUrl = getAppBaseUrl();
+  if (!linkUrl) return baseUrl;
+  try {
+    return new URL(linkUrl, `${baseUrl}/`).toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
+async function maybeSendNotificationEmail(
+  notificationId: string,
+  userId: string,
+  title: string,
+  body?: string | null,
+  linkUrl?: string | null
+) {
+  let userEmail: string | null = null;
+  let userName: string | null = null;
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { email: true, name: true },
+    });
+    userEmail = user?.email ?? null;
+    userName = user?.name ?? null;
+  } catch (error) {
+    if (isNotificationUnavailableError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  if (!userEmail) return;
+
+  const link = resolveNotificationUrl(linkUrl);
+  const greeting = userName ? `Bonjour ${userName},` : "Bonjour,";
+  const summary = body ? `\n\n${body}` : "";
+
+  try {
+    const delivered = await sendEmail({
+      to: userEmail,
+      subject: title,
+      text: `${greeting}\n\n${title}${summary}\n\nOuvrir: ${link}`,
+      html: [
+        `<p>${greeting}</p>`,
+        `<p><strong>${title}</strong></p>`,
+        body ? `<p>${body}</p>` : "",
+        `<p><a href="${link}">Ouvrir dans Homanager</a></p>`,
+      ]
+        .filter(Boolean)
+        .join(""),
+    });
+
+    if (delivered) {
+      await prisma.notification.update({
+        where: { id: notificationId },
+        data: { emailSentAt: new Date() },
+      });
+    }
+  } catch (error) {
+    console.warn("Impossible d'envoyer l'email de notification.", error);
+  }
+}
+
+export async function createNotification(options: NotificationOptions) {
+  try {
+    if (options.dedupeKey) {
+      const existing = await prisma.notification.findUnique({
+        where: { dedupeKey: options.dedupeKey },
+      });
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const notification = await prisma.notification.create({
+      data: {
+        userId: options.userId,
+        houseId: options.houseId,
+        type: options.type,
+        title: options.title,
+        body: options.body,
+        linkUrl: options.linkUrl,
+        dedupeKey: options.dedupeKey ?? undefined,
+      },
+    });
+
+    if (options.sendEmail) {
+      await maybeSendNotificationEmail(
+        notification.id,
+        options.userId,
+        options.title,
+        options.body,
+        options.linkUrl
+      );
+    }
+
+    return notification;
+  } catch (error) {
+    if (isNotificationUnavailableError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function notifyTaskAssigned(options: {
+  houseId: string;
+  taskId: string;
+  taskTitle: string;
+  assigneeId: string;
+  actorId: string;
+}) {
+  if (options.assigneeId === options.actorId) return;
+  await createNotification({
+    userId: options.assigneeId,
+    houseId: options.houseId,
+    type: "TASK_ASSIGNED",
+    title: `Nouvelle tâche assignée: ${options.taskTitle}`,
+    body: "Tu as une nouvelle tâche à prendre en charge.",
+    linkUrl: `/app/tasks/${options.taskId}`,
+    dedupeKey: `task-assigned:${options.taskId}:${options.assigneeId}`,
+    sendEmail: true,
+  });
+}
+
+export async function notifyTaskCommented(options: {
+  houseId: string;
+  taskId: string;
+  taskTitle: string;
+  recipientId: string;
+  actorId: string;
+}) {
+  if (options.recipientId === options.actorId) return;
+  await createNotification({
+    userId: options.recipientId,
+    houseId: options.houseId,
+    type: "TASK_COMMENTED",
+    title: `Nouveau commentaire sur "${options.taskTitle}"`,
+    body: "Un commentaire vient d'être ajouté.",
+    linkUrl: `/app/tasks/${options.taskId}`,
+    dedupeKey: `task-comment:${options.taskId}:${options.recipientId}:${Date.now()}`,
+    sendEmail: true,
+  });
+}
+
+export async function notifyTaskStatusChanged(options: {
+  houseId: string;
+  taskId: string;
+  taskTitle: string;
+  recipientId: string;
+  actorId: string;
+  status: "DONE" | "TODO" | "IN_PROGRESS";
+}) {
+  if (options.recipientId === options.actorId) return;
+  const statusLabel = options.status === "DONE" ? "terminée" : "mise à jour";
+  await createNotification({
+    userId: options.recipientId,
+    houseId: options.houseId,
+    type: "TASK_STATUS",
+    title: `Tâche ${statusLabel}: ${options.taskTitle}`,
+    body: `La tâche a été marquée comme ${statusLabel}.`,
+    linkUrl: `/app/tasks/${options.taskId}`,
+    dedupeKey: `task-status:${options.taskId}:${options.recipientId}:${options.status}`,
+    sendEmail: true,
+  });
+}
+
+export async function notifyProjectCreated(options: {
+  houseId: string;
+  projectId: string;
+  projectName: string;
+  actorId: string;
+}) {
+  const members = await prisma.houseMember.findMany({
+    where: { houseId: options.houseId },
+    select: { userId: true },
+  });
+
+  await Promise.all(
+    members
+      .map((member) => member.userId)
+      .filter((userId) => userId !== options.actorId)
+      .map((userId) =>
+        createNotification({
+          userId,
+          houseId: options.houseId,
+          type: "PROJECT_CREATED",
+          title: `Nouveau projet: ${options.projectName}`,
+          body: "Un nouveau projet a été ajouté à la maison.",
+          linkUrl: `/app/projects`,
+          dedupeKey: `project-created:${options.projectId}:${userId}`,
+          sendEmail: true,
+        })
+      )
+  );
+}
+
+export async function notifyInviteAccepted(options: {
+  houseId: string;
+  inviterId: string;
+  inviteeName?: string | null;
+}) {
+  await createNotification({
+    userId: options.inviterId,
+    houseId: options.houseId,
+    type: "INVITE_ACCEPTED",
+    title: "Invitation acceptée",
+    body: options.inviteeName
+      ? `${options.inviteeName} a rejoint la maison.`
+      : "Un membre a rejoint la maison.",
+    linkUrl: "/app/settings",
+    dedupeKey: `invite-accepted:${options.houseId}:${options.inviterId}:${options.inviteeName ?? "member"}`,
+    sendEmail: true,
+  });
+}
+
+export async function ensureTaskReminders(houseId: string) {
+  const today = startOfDay(new Date());
+
+  try {
+    const tasks = await prisma.task.findMany({
+      where: {
+        houseId,
+        isTemplate: false,
+        status: { not: "DONE" },
+        dueDate: { not: null },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        reminderOffsetDays: true,
+        assigneeId: true,
+        createdById: true,
+      },
+    });
+
+    await Promise.all(
+      tasks.map(async (task) => {
+        if (!task.dueDate) return;
+        const reminderOffset = task.reminderOffsetDays ?? 0;
+        const reminderDate = startOfDay(subDays(task.dueDate, reminderOffset));
+        if (!isSameDay(reminderDate, today)) return;
+
+        const recipientId = task.assigneeId ?? task.createdById;
+        const dateLabel = format(task.dueDate, "dd/MM/yyyy");
+        const dedupeKey = `task-reminder:${task.id}:${recipientId}:${format(
+          reminderDate,
+          "yyyy-MM-dd"
+        )}`;
+
+        await createNotification({
+          userId: recipientId,
+          houseId,
+          type: "TASK_REMINDER",
+          title: `Rappel: ${task.title}`,
+          body: `Échéance prévue le ${dateLabel}.`,
+          linkUrl: `/app/tasks/${task.id}`,
+          dedupeKey,
+          sendEmail: true,
+        });
+      })
+    );
+  } catch (error) {
+    if (isNotificationUnavailableError(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+export async function getUnreadNotificationCount(userId: string) {
+  try {
+    return await prisma.notification.count({
+      where: { userId, readAt: null },
+    });
+  } catch (error) {
+    if (isNotificationUnavailableError(error)) {
+      return 0;
+    }
+    throw error;
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,15 @@ enum InviteStatus {
   EXPIRED
 }
 
+enum NotificationType {
+  TASK_ASSIGNED
+  TASK_COMMENTED
+  TASK_STATUS
+  TASK_REMINDER
+  PROJECT_CREATED
+  INVITE_ACCEPTED
+}
+
 enum AgentMessageRole {
   USER
   ASSISTANT
@@ -87,6 +96,7 @@ model User {
   createdBudgetEntries BudgetEntry[] @relation("BudgetEntryCreator")
   createdBudgetRecurringEntries BudgetRecurringEntry[] @relation("BudgetRecurringCreator")
   uploadedBudgetDocuments BudgetDocument[] @relation("BudgetDocumentUploader")
+  notifications Notification[]
 }
 
 model Account {
@@ -151,6 +161,27 @@ model House {
   budgetEntries BudgetEntry[]
   budgetRecurringEntries BudgetRecurringEntry[]
   budgetDocuments BudgetDocument[]
+  notifications Notification[]
+}
+
+model Notification {
+  id          String           @id @default(cuid())
+  userId      String
+  houseId     String
+  type        NotificationType
+  title       String
+  body        String?
+  linkUrl     String?
+  createdAt   DateTime         @default(now())
+  readAt      DateTime?
+  emailSentAt DateTime?
+  dedupeKey   String?          @unique
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  house House @relation(fields: [houseId], references: [id], onDelete: Cascade)
+
+  @@index([userId, readAt])
+  @@index([houseId, createdAt])
 }
 
 model HouseMember {


### PR DESCRIPTION
### Motivation
- Fournir un système de notifications pour les événements collaboratifs importants (assignation de tâches, commentaires, changements de statut, rappels, création de projets, acceptation d'invitations) afin d'améliorer la coordination entre membres.
- Proposer une diffusion par e-mail en complément de la notification in-app pour s'assurer que les utilisateurs reçoivent les alertes critiques même hors session.

### Description
- Ajout d'un modèle Prisma `Notification` et d'une enum `NotificationType` avec relations vers `User` et `House`, index et clé de déduplication pour éviter les doublons, et champs `readAt` / `emailSentAt` (fichier `prisma/schema.prisma`).
- Nouveau module `lib/notifications.ts` exposant `createNotification`, helpers `notifyTaskAssigned`, `notifyTaskCommented`, `notifyTaskStatusChanged`, `notifyProjectCreated`, `notifyInviteAccepted`, `ensureTaskReminders`, et `getUnreadNotificationCount`, avec envoi d'e-mails via `lib/email` et logique de déduplication.
- Intégration des rappels périodiques dans le flux maison via `ensureTaskReminders` appelé depuis `getHouseData` (fichier `lib/house.ts`).
- UI: ajout d'une page `/app/notifications` listant les notifications et d'un badge non-lu dans la sidebar/app shell pour afficher le compteur d'items non lus (fichiers `app/(app)/app/notifications/page.tsx`, `app/(app)/layout.tsx`, `components/layout/app-shell.tsx`, `components/layout/sidebar.tsx`).
- Déclenchement des notifications depuis les actions existantes pour la création de projet, création/assignation/maj de tâches, commentaires, et acceptation d'invitations, ainsi qu'actions serveur pour marquer une notification lue ou toutes les marquer comme lues (fichier `app/actions.ts`).
- Amélioration: l'enregistrement `emailSentAt` n'est mis à jour que si l'envoi d'e-mail retourne un résultat positif; les pages et chemins sont revalidés pour inclure `/app/notifications`.

### Testing
- Démarrage du serveur de développement via `npm run dev` : le serveur Next a démarré et compilé la plupart des pages, mais certaines requêtes vers Google Fonts ont échoué en environnement CI (warnings) et NextAuth/Prisma a renvoyé une erreur lors d'une tentative de connexion parce que la variable d'environnement `DATABASE_URL` est absente, entraînant un `500` sur l'endpoint d'auth (Prisma initialization error).
- Test d'interface via un script Playwright (navigation + tentative d'envoi du lien magique) : le script Python s'est exécuté et a produit une capture d'écran de la page de connexion, mais la requête POST d'auth a échoué pour la raison d'environnement ci-dessus, donc la page d'authentification et la page de notifications n'ont pas pu être entièrement validées en session authentifiée.
- Aucune suite de tests unitaires/CI supplémentaire n'a été exécutée ici; pour appliquer la base de données et tester localement, exécuter `npm run db:push` puis relancer le serveur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698978d2f7b88333ae85824e43377cc2)